### PR TITLE
feat(plex): Added library counts

### DIFF
--- a/examples/dashboards/Media Server.json
+++ b/examples/dashboards/Media Server.json
@@ -451,6 +451,64 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-green",
+            "mode": "fixed"
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 5
+      },
+      "id": 999,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "max"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0-cloud.5.a016665c",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(plex_library_items{job=~\"$job\", instance=~\"$instance\", server=~\"$server\"}) by (library)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{library}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Library Items",
+      "type": "stat"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
@@ -882,6 +940,114 @@
         }
       ],
       "type": "barchart"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 44
+      },
+      "id": 2000,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0-cloud.5.a016665c",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "plex_media_movies{job=~\"$job\", instance=~\"$instance\", server=~\"$server\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Movies",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 44
+      },
+      "id": 2001,
+      "links": [],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.0-cloud.5.a016665c",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "plex_media_episodes{job=~\"$job\", instance=~\"$instance\", server=~\"$server\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total Episodes",
+      "type": "stat"
     },
     {
       "datasource": {

--- a/mixin/dashboard.libsonnet
+++ b/mixin/dashboard.libsonnet
@@ -290,6 +290,31 @@ local storageStat =
     },
   };
 
+local libraryItemsStat =
+  statPanel.new(
+    'Library Items',
+    datasource='$datasource',
+    unit='short',
+    reducerFunction='max',
+    graphMode='none',
+    colorMode='background',
+  )
+  .addTarget(
+    grafana.prometheus.target(
+      'sum(plex_library_items{' + matcher + '}) by (library)',
+      legendFormat='{{library}}',
+    )
+  ) + {
+    fieldConfig+: {
+      defaults+: {
+        color: {
+          mode: 'fixed',
+          fixedColor: 'light-green',
+        },
+      },
+    },
+  };
+
 local durationGraph =
   graphPanel.new(
     'Duration',
@@ -755,7 +780,8 @@ local playback_dashboard =
     durationStat { gridPos: { h: 4, w: 15, x: 9, y: 1 } },
     plexVerStat { gridPos: { h: 4, w: 6, x: 0, y: 5 } },
     hostMemStat { gridPos: { h: 4, w: 3, x: 6, y: 5 } },
-    storageStat { gridPos: { h: 4, w: 15, x: 9, y: 5 } },
+  storageStat { gridPos: { h: 4, w: 10, x: 9, y: 5 } },
+  libraryItemsStat { gridPos: { h: 4, w: 5, x: 19, y: 5 } },
     networkTs { gridPos: { h: 7, w: 24, x: 0, y: 9 } },
     grafana.row.new('Duration') { gridPos: { h: 1, w: 24, x: 0, y: 16 } },
     durationGraph { gridPos: { h: 7, w: 24, x: 0, y: 17 } },

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,6 +59,16 @@ var (
 		nil,
 	)
 
+	// plex_library_items is a gauge representing the instantaneous number of
+	// items contained in a library (section). Use a plain gauge (no _total)
+	// to follow Prometheus conventions for instantaneous sizes.
+	MetricsLibraryItemsDesc = prometheus.NewDesc(
+		"plex_library_items",
+		"Number of items in a library section",
+		libraryLabels,
+		nil,
+	)
+
 	MetricPlayCountDesc = prometheus.NewDesc(
 		"plays_total",
 		"Total play counts",
@@ -81,6 +91,21 @@ var (
 	MetricTransmittedBytesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "transmit_bytes_total",
 	}, serverLabels)
+
+	// plex_media_movies / plex_media_episodes are gauges with server-level labels
+	MetricsMediaMoviesDesc = prometheus.NewDesc(
+		"plex_media_movies",
+		"Total number of movie items across all libraries for a server",
+		serverLabels,
+		nil,
+	)
+
+	MetricsMediaEpisodesDesc = prometheus.NewDesc(
+		"plex_media_episodes",
+		"Total number of episode items across all libraries for a server",
+		serverLabels,
+		nil,
+	)
 )
 
 func Register(collectors ...prometheus.Collector) {
@@ -111,6 +136,27 @@ func LibraryStorage(value int64,
 		serverType, serverName, serverID,
 		libraryType, libraryName, libraryID,
 	)
+}
+
+func LibraryItems(value int64,
+	serverType, serverName, serverID,
+	libraryType, libraryName, libraryID string,
+) prometheus.Metric {
+
+	return prometheus.MustNewConstMetric(MetricsLibraryItemsDesc,
+		prometheus.GaugeValue,
+		float64(value),
+		serverType, serverName, serverID,
+		libraryType, libraryName, libraryID,
+	)
+}
+
+func MediaMovies(value int64, serverType, serverName, serverID string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(MetricsMediaMoviesDesc, prometheus.GaugeValue, float64(value), serverType, serverName, serverID)
+}
+
+func MediaEpisodes(value int64, serverType, serverName, serverID string) prometheus.Metric {
+	return prometheus.MustNewConstMetric(MetricsMediaEpisodesDesc, prometheus.GaugeValue, float64(value), serverType, serverName, serverID)
 }
 
 func Play(value float64, serverType, serverName, serverID,

--- a/pkg/plex/library.go
+++ b/pkg/plex/library.go
@@ -9,6 +9,7 @@ type Library struct {
 
 	DurationTotal int64
 	StorageTotal  int64
+	ItemsCount    int64
 }
 
 func isLibraryDirectoryType(directoryType string) bool {

--- a/pkg/plex/server_test.go
+++ b/pkg/plex/server_test.go
@@ -1,0 +1,105 @@
+package plex
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/grafana/plexporter/pkg/metrics"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// fakeRoundTripper returns canned responses for known Plex endpoints
+type fakeRoundTripper struct{}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+	switch {
+	case req.URL.Path == "/media/providers":
+		body = `{"MediaContainer": {"friendlyName":"TestServer","machineIdentifier":"machine123","version":"1.2.3","MediaProvider":[{"identifier":"com.plexapp.plugins.library","Feature":[{"type":"content","Directory":[{"id":"1","durationTotal":1000,"storageTotal":2000,"title":"Movies","type":"movie"},{"id":"2","durationTotal":2000,"storageTotal":3000,"title":"Shows","type":"show"}]}]}]}}`
+	case req.URL.Path == "/library/sections/1/all":
+		body = `{"MediaContainer":{"size":10}}`
+	case req.URL.Path == "/library/sections/2/all":
+		body = `{"MediaContainer":{"size":20}}`
+	case req.URL.Path == "/":
+		body = `{"MediaContainer":{"version":"v","platform":"p","platformVersion":"pv"}}`
+	case req.URL.Path == "/statistics/resources":
+		body = `{"MediaContainer":{"StatisticsResources":[{"at":1,"hostCpuUtilization":5,"hostMemoryUtilization":6}]}}`
+	case req.URL.Path == "/statistics/bandwidth":
+		body = `{"MediaContainer":{"StatisticsBandwith":[]}}`
+	default:
+		body = `{"MediaContainer":{}}`
+	}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	return resp, nil
+}
+
+func TestServerRefreshPopulatesLibraryItems(t *testing.T) {
+	client, err := NewClient("http://example.com", "token")
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+
+	// Replace the http client transport with our fake RT
+	client.httpClient = http.Client{Transport: &fakeRoundTripper{}, Timeout: time.Second * 2}
+
+	srv := &Server{
+		URL:             client.URL,
+		Token:           client.Token,
+		Client:          client,
+		lastBandwidthAt: int(time.Now().Unix()),
+	}
+
+	if err := srv.Refresh(); err != nil {
+		t.Fatalf("Refresh error: %v", err)
+	}
+
+	if len(srv.libraries) != 2 {
+		t.Fatalf("expected 2 libraries, got %d", len(srv.libraries))
+	}
+
+	// Check item counts for each library
+	expected := map[string]int64{"1": 10, "2": 20}
+	for _, lib := range srv.libraries {
+		want, ok := expected[lib.ID]
+		if !ok {
+			t.Fatalf("unexpected library id %s", lib.ID)
+		}
+		if lib.ItemsCount != want {
+			t.Fatalf("library %s items: want %d got %d", lib.ID, want, lib.ItemsCount)
+		}
+
+		// Validate the metric produced by metrics.LibraryItems matches value & labels
+		m := metrics.LibraryItems(lib.ItemsCount, "plex", srv.Name, srv.ID, lib.Type, lib.Name, lib.ID)
+		var dtoMetric dto.Metric
+		if err := m.Write(&dtoMetric); err != nil {
+			t.Fatalf("failed to write metric: %v", err)
+		}
+
+		if dtoMetric.GetGauge() == nil {
+			t.Fatalf("expected gauge metric")
+		}
+		if dtoMetric.GetGauge().GetValue() != float64(want) {
+			t.Fatalf("metric value mismatch: want %v got %v", want, dtoMetric.GetGauge().GetValue())
+		}
+
+		// Ensure some expected labels are present
+		labels := map[string]bool{}
+		for _, lp := range dtoMetric.Label {
+			labels[lp.GetValue()] = true
+		}
+		if !labels[srv.Name] || !labels[srv.ID] || !labels[lib.Name] || !labels[lib.ID] {
+			t.Fatalf("expected labels missing in metric: %v", dtoMetric.Label)
+		}
+	}
+}

--- a/pkg/plex/server_totals_test.go
+++ b/pkg/plex/server_totals_test.go
@@ -1,0 +1,89 @@
+package plex
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// fakeTotalsRoundTripper returns canned responses for endpoints used to
+// compute server-level movie and episode totals.
+type fakeTotalsRoundTripper struct{}
+
+func (f *fakeTotalsRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+	switch {
+	case req.URL.Path == "/media/providers":
+		body = `{"MediaContainer": {"friendlyName":"TotalsServer","machineIdentifier":"machine-totals","version":"1.0","MediaProvider":[{"identifier":"com.plexapp.plugins.library","Feature":[{"type":"content","Directory":[{"id":"m1","durationTotal":100,"storageTotal":100,"title":"MoviesA","type":"movie"},{"id":"m2","durationTotal":200,"storageTotal":200,"title":"MoviesB","type":"movie"},{"id":"s1","durationTotal":300,"storageTotal":300,"title":"Shows","type":"show"}]}]}]}}`
+	case req.URL.Path == "/library/sections/m1/all":
+		body = `{"MediaContainer":{"size":7}}`
+	case req.URL.Path == "/library/sections/m2/all":
+		body = `{"MediaContainer":{"size":3}}`
+	case req.URL.Path == "/library/sections/s1/all" && req.URL.RawQuery == "type=4":
+		// Filtered episodes request
+		body = `{"MediaContainer":{"size":42}}`
+	case req.URL.Path == "/library/sections/s1/all":
+		// Unfiltered call used by Refresh(); return 0 to force the
+		// filtered type=4 request to be used for episode counting.
+		body = `{"MediaContainer":{"size":0}}`
+	case req.URL.RawQuery == "":
+		// fallback
+		body = `{"MediaContainer":{}}`
+	default:
+		// handle the filtered episodes call
+		if req.URL.Path == "/library/sections/s1/all" && req.URL.RawQuery == "type=4" {
+			body = `{"MediaContainer":{"size":42}}`
+		} else if req.URL.Path == "/" {
+			body = `{"MediaContainer":{"version":"v","platform":"p","platformVersion":"pv"}}`
+		} else if req.URL.Path == "/statistics/resources" {
+			body = `{"MediaContainer":{"StatisticsResources":[]}}`
+		} else if req.URL.Path == "/statistics/bandwidth" {
+			body = `{"MediaContainer":{"StatisticsBandwith":[]}}`
+		} else {
+			body = `{"MediaContainer":{}}`
+		}
+	}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Status:     "200 OK",
+		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}
+	resp.Header.Set("Content-Type", "application/json")
+	return resp, nil
+}
+
+func TestServerTotalsComputed(t *testing.T) {
+	client, err := NewClient("http://example.com", "token")
+	if err != nil {
+		t.Fatalf("NewClient error: %v", err)
+	}
+
+	// Replace the http client transport with our fake RT
+	client.httpClient = http.Client{Transport: &fakeTotalsRoundTripper{}, Timeout: time.Second * 2}
+
+	srv := &Server{
+		URL:             client.URL,
+		Token:           client.Token,
+		Client:          client,
+		lastBandwidthAt: int(time.Now().Unix()),
+	}
+
+	if err := srv.Refresh(); err != nil {
+		t.Fatalf("Refresh error: %v", err)
+	}
+
+	// Movie totals: m1 (7) + m2 (3) = 10
+	if srv.MovieCount != 10 {
+		t.Fatalf("expected MovieCount 10, got %d", srv.MovieCount)
+	}
+
+	// Episode totals: s1 type=4 returns 42
+	if srv.EpisodeCount != 42 {
+		t.Fatalf("expected EpisodeCount 42, got %d", srv.EpisodeCount)
+	}
+}


### PR DESCRIPTION
- `plex_library_items` (gauge): instantaneous item count per library. Labels: `server_type`, `server`, `server_id`, `library_type`, `library`, `library_id`.
- `plex_media_movies` (gauge): total number of movies across all movie libraries. Labels: `server_type`, `server`, `server_id`.
- `plex_media_episodes` (gauge): total number of episodes across all show libraries. Labels: `server_type`, `server`, `server_id`.

Notes:

- Counts are best-effort and are fetched from the Plex library endpoints. If the exporter cannot reach the Plex server for a particular library, that library's count will be omitted for that refresh cycle.
- Episode counting for show libraries uses a filtered Plex query (`?type=4`) and the exporter performs those calls in parallel with a small concurrency limit to avoid overloading the Plex server.
- Example Grafana panels showing these metrics are included under `examples/dashboards/Media Server.json` and the mixin at `mixin/dashboard.libsonnet`.