### PR TITLE
fix(plex): Fixed types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
       - run: go test -v -mod vendor ./...
         env:
           CGO_ENABLED: "0"
+      - name: Run vendor package tests
+        run: |
+          # Run tests that live in the vendor directory. These validate fixes in the vendored client.
+          go test -v ./vendor/...
+        env:
+          CGO_ENABLED: "0"
 
   build:
     runs-on: ubuntu-latest

--- a/pkg/plex/invite_integration_test.go
+++ b/pkg/plex/invite_integration_test.go
@@ -1,0 +1,42 @@
+package plex
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	jrplex "github.com/jrudio/go-plex-client"
+)
+
+func TestInviteFriendEndToEnd(t *testing.T) {
+	// httptest server to accept the invite request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || !strings.HasSuffix(r.URL.Path, "/api/v2/shared_servers") {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		if !bytes.Contains(body, []byte("invitedEmail")) {
+			t.Fatalf("request missing invitedEmail: %s", string(body))
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"1","ownerId":"2","invitedId":"3","serverId":"4","numLibraries":"0","invited":{"id":"5"},"sharingSettings":{"allowTuners":"0"},"libraries":[]}`))
+	}))
+	defer srv.Close()
+
+	// create a client that points to the test server
+	p, err := jrplex.New(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	params := jrplex.InviteFriendParams{UsernameOrEmail: "a@b.c", MachineID: "m", Label: "", LibraryIDs: []int{1}}
+	if err := p.InviteFriend(params); err != nil {
+		t.Fatalf("InviteFriend failed: %v", err)
+	}
+}

--- a/pkg/plex/models_unmarshal_test.go
+++ b/pkg/plex/models_unmarshal_test.go
@@ -1,0 +1,78 @@
+package plex
+
+import (
+	"encoding/json"
+	"testing"
+
+	plexclient "github.com/jrudio/go-plex-client"
+)
+
+func TestMetadataQuotedLibrarySectionIDAndViewCount(t *testing.T) {
+	payload := `{"librarySectionID":"15","viewCount":"7"}`
+
+	var m plexclient.Metadata
+	if err := json.Unmarshal([]byte(payload), &m); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if m.LibrarySectionID != 15 {
+		t.Fatalf("expected LibrarySectionID 15, got %d", m.LibrarySectionID)
+	}
+	if m.ViewCount != 7 {
+		t.Fatalf("expected ViewCount 7, got %d", m.ViewCount)
+	}
+}
+
+func TestTaggedDataQuotedID(t *testing.T) {
+	payload := `{"tag":"g","filter":"f","id":"99"}`
+
+	var td plexclient.TaggedData
+	if err := json.Unmarshal([]byte(payload), &td); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if td.ID != 99 {
+		t.Fatalf("expected TaggedData.ID 99, got %d", td.ID)
+	}
+}
+
+func TestPartAndStreamQuotedIDs(t *testing.T) {
+	var s plexclient.Stream
+	// Unmarshal as Stream object
+	if err := json.Unmarshal([]byte(`{"id":"33"}`), &s); err != nil {
+		t.Fatalf("unmarshal stream failed: %v", err)
+	}
+	if s.ID != 33 {
+		t.Fatalf("expected Stream.ID 33, got %d", s.ID)
+	}
+
+	// Unmarshal Part with quoted id
+	var p plexclient.Part
+	if err := json.Unmarshal([]byte(`{"id":"11","Stream":[{"id":"33"}]}`), &p); err != nil {
+		t.Fatalf("unmarshal part failed: %v", err)
+	}
+	if p.ID != 11 {
+		t.Fatalf("expected Part.ID 11, got %d", p.ID)
+	}
+	if len(p.Stream) != 1 || p.Stream[0].ID != 33 {
+		t.Fatalf("expected nested Stream.ID 33, got %+v", p.Stream)
+	}
+}
+
+func TestRatingAndGenreQuotedValues(t *testing.T) {
+	var r plexclient.Rating
+	if err := json.Unmarshal([]byte(`{"image":"i","type":"t","value":"5"}`), &r); err != nil {
+		t.Fatalf("unmarshal rating failed: %v", err)
+	}
+	if r.Value != 5 {
+		t.Fatalf("expected Rating.Value 5, got %d", r.Value)
+	}
+
+	var g plexclient.Genre
+	if err := json.Unmarshal([]byte(`{"filter":"f","id":"7","tag":"tt"}`), &g); err != nil {
+		t.Fatalf("unmarshal genre failed: %v", err)
+	}
+	if g.ID != 7 {
+		t.Fatalf("expected Genre.ID 7, got %d", g.ID)
+	}
+}

--- a/pkg/plex/sessions.go
+++ b/pkg/plex/sessions.go
@@ -138,7 +138,7 @@ func (s *sessions) Collect(ch chan<- prometheus.Metric) {
 		}
 
 		title, season, episode := labels(session.media)
-		library := s.server.Library(session.media.LibrarySectionID.String())
+		library := s.server.Library(strconv.FormatInt(session.media.LibrarySectionID.Int64(), 10))
 		if library == nil {
 			continue
 		}

--- a/pkg/plex/websocket_unmarshal_test.go
+++ b/pkg/plex/websocket_unmarshal_test.go
@@ -1,0 +1,68 @@
+package plex
+
+import (
+	"encoding/json"
+	"testing"
+
+	plexclient "github.com/jrudio/go-plex-client"
+)
+
+func TestTimelineEntryQuotedIDs(t *testing.T) {
+	payload := `{"NotificationContainer": {"TimelineEntry": [{"identifier":"abc","itemID":"123","metadataState":"ok","sectionID":"15","state":2,"title":"Test","type":1,"updatedAt":1600000000}], "size":1, "type":"playing"}}`
+
+	var notif plexclient.WebsocketNotification
+	if err := json.Unmarshal([]byte(payload), &notif); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(notif.NotificationContainer.TimelineEntry) != 1 {
+		t.Fatalf("expected 1 timeline entry, got %d", len(notif.NotificationContainer.TimelineEntry))
+	}
+
+	te := notif.NotificationContainer.TimelineEntry[0]
+	if te.ItemID != 123 {
+		t.Fatalf("expected ItemID 123, got %d", te.ItemID)
+	}
+	if te.SectionID != 15 {
+		t.Fatalf("expected SectionID 15, got %d", te.SectionID)
+	}
+}
+
+func TestActivityNotificationQuotedUserID(t *testing.T) {
+	payload := `{"NotificationContainer": {"ActivityNotification": [{"Activity": {"cancellable": false, "progress": 0, "subtitle": "", "title": "Test", "type": "test", "userID": "42", "uuid": "u1"}, "event": "activity", "uuid": "u1"}], "size":1, "type":"activity"}}`
+
+	var notif plexclient.WebsocketNotification
+	if err := json.Unmarshal([]byte(payload), &notif); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(notif.NotificationContainer.ActivityNotification) != 1 {
+		t.Fatalf("expected 1 activity entry, got %d", len(notif.NotificationContainer.ActivityNotification))
+	}
+
+	act := notif.NotificationContainer.ActivityNotification[0]
+	if act.Activity.UserID != 42 {
+		t.Fatalf("expected Activity.UserID 42, got %d", act.Activity.UserID)
+	}
+}
+
+func TestPlaySessionStateNotificationQuotedIDs(t *testing.T) {
+	payload := `{"NotificationContainer": {"PlaySessionStateNotification": [{"guid":"g","key":"k","playQueueItemID":"7","ratingKey":"r","sessionKey":"s","state":"playing","url":"","viewOffset":"900","transcodeSession":""}], "size":1, "type":"playing"}}`
+
+	var notif plexclient.WebsocketNotification
+	if err := json.Unmarshal([]byte(payload), &notif); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(notif.NotificationContainer.PlaySessionStateNotification) != 1 {
+		t.Fatalf("expected 1 play session entry, got %d", len(notif.NotificationContainer.PlaySessionStateNotification))
+	}
+
+	ps := notif.NotificationContainer.PlaySessionStateNotification[0]
+	if ps.PlayQueueItemID != 7 {
+		t.Fatalf("expected PlayQueueItemID 7, got %d", ps.PlayQueueItemID)
+	}
+	if ps.ViewOffset != 900 {
+		t.Fatalf("expected ViewOffset 900, got %d", ps.ViewOffset)
+	}
+}

--- a/vendor/github.com/jrudio/go-plex-client/models.go
+++ b/vendor/github.com/jrudio/go-plex-client/models.go
@@ -8,6 +8,20 @@ import (
 	"time"
 )
 
+// FlexibleInt64 handles JSON values that may be numbers or quoted strings.
+type FlexibleInt64 int64
+
+func (f *FlexibleInt64) UnmarshalJSON(b []byte) error {
+	v, err := parseFlexibleInt64(b)
+	if err != nil {
+		return err
+	}
+	*f = FlexibleInt64(v)
+	return nil
+}
+
+func (f FlexibleInt64) Int64() int64 { return int64(f) }
+
 // Plex contains fields that are required to make
 // an api call to your plex server
 type Plex struct {
@@ -42,51 +56,51 @@ type SearchResults struct {
 
 // Metadata ...
 type Metadata struct {
-	Player                Player       `json:"Player"`
-	Session               Session      `json:"Session"`
-	User                  User         `json:"User"`
-	AddedAt               int          `json:"addedAt"`
-	Art                   string       `json:"art"`
-	ContentRating         string       `json:"contentRating"`
-	Duration              int          `json:"duration"`
-	Genres                []Genre      `json:"Genre"`
-	GrandparentArt        string       `json:"grandparentArt"`
-	GrandparentKey        string       `json:"grandparentKey"`
-	GrandparentRatingKey  string       `json:"grandparentRatingKey"`
-	GrandparentTheme      string       `json:"grandparentTheme"`
-	GrandparentThumb      string       `json:"grandparentThumb"`
-	GrandparentTitle      string       `json:"grandparentTitle"`
-	GUID                  string       `json:"guid"`
-	AltGUIDs              []AltGUID    `json:"Guid"`
-	Index                 int64        `json:"index"`
-	Key                   string       `json:"key"`
-	LastViewedAt          int          `json:"lastViewedAt"`
-	LibrarySectionID      json.Number  `json:"librarySectionID"`
-	LibrarySectionKey     string       `json:"librarySectionKey"`
-	LibrarySectionTitle   string       `json:"librarySectionTitle"`
-	OriginallyAvailableAt string       `json:"originallyAvailableAt"`
-	ParentIndex           int64        `json:"parentIndex"`
-	ParentKey             string       `json:"parentKey"`
-	ParentRatingKey       string       `json:"parentRatingKey"`
-	ParentThumb           string       `json:"parentThumb"`
-	ParentTitle           string       `json:"parentTitle"`
-	RatingCount           int          `json:"ratingCount"`
-	Rating                float64      `json:"rating"`
-	Ratings               []Rating     `json:"Rating"`
-	RatingKey             string       `json:"ratingKey"`
-	SessionKey            string       `json:"sessionKey"`
-	Summary               string       `json:"summary"`
-	Thumb                 string       `json:"thumb"`
-	Media                 []Media      `json:"Media"`
-	Title                 string       `json:"title"`
-	TitleSort             string       `json:"titleSort"`
-	Type                  string       `json:"type"`
-	UpdatedAt             int          `json:"updatedAt"`
-	ViewCount             json.Number  `json:"viewCount"`
-	ViewOffset            int          `json:"viewOffset"`
-	Year                  int          `json:"year"`
-	Director              []TaggedData `json:"Director"`
-	Writer                []TaggedData `json:"Writer"`
+	Player                Player        `json:"Player"`
+	Session               Session       `json:"Session"`
+	User                  User          `json:"User"`
+	AddedAt               int           `json:"addedAt"`
+	Art                   string        `json:"art"`
+	ContentRating         string        `json:"contentRating"`
+	Duration              int           `json:"duration"`
+	Genres                []Genre       `json:"Genre"`
+	GrandparentArt        string        `json:"grandparentArt"`
+	GrandparentKey        string        `json:"grandparentKey"`
+	GrandparentRatingKey  string        `json:"grandparentRatingKey"`
+	GrandparentTheme      string        `json:"grandparentTheme"`
+	GrandparentThumb      string        `json:"grandparentThumb"`
+	GrandparentTitle      string        `json:"grandparentTitle"`
+	GUID                  string        `json:"guid"`
+	AltGUIDs              []AltGUID     `json:"Guid"`
+	Index                 int64         `json:"index"`
+	Key                   string        `json:"key"`
+	LastViewedAt          int           `json:"lastViewedAt"`
+	LibrarySectionID      FlexibleInt64 `json:"librarySectionID"`
+	LibrarySectionKey     string        `json:"librarySectionKey"`
+	LibrarySectionTitle   string        `json:"librarySectionTitle"`
+	OriginallyAvailableAt string        `json:"originallyAvailableAt"`
+	ParentIndex           int64         `json:"parentIndex"`
+	ParentKey             string        `json:"parentKey"`
+	ParentRatingKey       string        `json:"parentRatingKey"`
+	ParentThumb           string        `json:"parentThumb"`
+	ParentTitle           string        `json:"parentTitle"`
+	RatingCount           int           `json:"ratingCount"`
+	Rating                float64       `json:"rating"`
+	Ratings               []Rating      `json:"Rating"`
+	RatingKey             string        `json:"ratingKey"`
+	SessionKey            string        `json:"sessionKey"`
+	Summary               string        `json:"summary"`
+	Thumb                 string        `json:"thumb"`
+	Media                 []Media       `json:"Media"`
+	Title                 string        `json:"title"`
+	TitleSort             string        `json:"titleSort"`
+	Type                  string        `json:"type"`
+	UpdatedAt             int           `json:"updatedAt"`
+	ViewCount             FlexibleInt64 `json:"viewCount"`
+	ViewOffset            int           `json:"viewOffset"`
+	Year                  int           `json:"year"`
+	Director              []TaggedData  `json:"Director"`
+	Writer                []TaggedData  `json:"Writer"`
 }
 
 // AltGUID represents a Globally Unique Identifier for a metadata provider that is not actively being used.
@@ -127,24 +141,24 @@ func (b *boolOrInt) UnmarshalJSON(data []byte) error {
 
 // Media media info
 type Media struct {
-	AspectRatio           json.Number `json:"aspectRatio"`
-	AudioChannels         int         `json:"audioChannels"`
-	AudioCodec            string      `json:"audioCodec"`
-	AudioProfile          string      `json:"audioProfile"`
-	Bitrate               int         `json:"bitrate"`
-	Container             string      `json:"container"`
-	Duration              int         `json:"duration"`
-	Has64bitOffsets       bool        `json:"has64bitOffsets"`
-	Height                int         `json:"height"`
-	ID                    json.Number `json:"id"`
-	OptimizedForStreaming boolOrInt   `json:"optimizedForStreaming"` // plex can return int (GetMetadata(), GetPlaylist()) or boolean (GetSessions()): 0 or 1; true or false
-	Selected              bool        `json:"selected"`
-	VideoCodec            string      `json:"videoCodec"`
-	VideoFrameRate        string      `json:"videoFrameRate"`
-	VideoProfile          string      `json:"videoProfile"`
-	VideoResolution       string      `json:"videoResolution"`
-	Width                 int         `json:"width"`
-	Part                  []Part      `json:"Part"`
+	AspectRatio           json.Number   `json:"aspectRatio"`
+	AudioChannels         int           `json:"audioChannels"`
+	AudioCodec            string        `json:"audioCodec"`
+	AudioProfile          string        `json:"audioProfile"`
+	Bitrate               int           `json:"bitrate"`
+	Container             string        `json:"container"`
+	Duration              int           `json:"duration"`
+	Has64bitOffsets       bool          `json:"has64bitOffsets"`
+	Height                int           `json:"height"`
+	ID                    FlexibleInt64 `json:"id"`
+	OptimizedForStreaming boolOrInt     `json:"optimizedForStreaming"` // plex can return int (GetMetadata(), GetPlaylist()) or boolean (GetSessions()): 0 or 1; true or false
+	Selected              bool          `json:"selected"`
+	VideoCodec            string        `json:"videoCodec"`
+	VideoFrameRate        string        `json:"videoFrameRate"`
+	VideoProfile          string        `json:"videoProfile"`
+	VideoResolution       string        `json:"videoResolution"`
+	Width                 int           `json:"width"`
+	Part                  []Part        `json:"Part"`
 }
 
 // MediaContainer contains media info
@@ -200,9 +214,9 @@ type LibrarySections struct {
 
 // TaggedData ...
 type TaggedData struct {
-	Tag    string      `json:"tag"`
-	Filter string      `json:"filter"`
-	ID     json.Number `json:"id"`
+	Tag    string        `json:"tag"`
+	Filter string        `json:"filter"`
+	ID     FlexibleInt64 `json:"id"`
 }
 
 // Role ...
@@ -355,50 +369,143 @@ type resultResponse struct {
 }
 
 type inviteFriendResponse struct {
-	ID                json.Number `json:"id"`
-	Name              string      `json:"name"`
-	OwnerID           json.Number `json:"ownerId"`
-	InvitedID         json.Number `json:"invitedId"`
-	InvitedEmail      string      `json:"invitedEmail"`
-	ServerID          json.Number `json:"serverId"`
-	Accepted          bool        `json:"accepted"`
-	AcceptedAt        string      `json:"acceptedAt"`
-	DeletedAt         string      `json:"deletedAt"`
-	LeftAt            string      `json:"leftAt"`
-	Owned             bool        `json:"owned"`
-	InviteToken       string      `json:"inviteToken"`
-	MachineIdentifier string      `json:"machineIdentifier"`
-	LastSeenAt        time.Time   `json:"lastSeenAt"`
-	NumLibraries      json.Number `json:"numLibraries"`
+	ID                int64  `json:"id"`
+	Name              string `json:"name"`
+	OwnerID           int64  `json:"ownerId"`
+	InvitedID         int64  `json:"invitedId"`
+	InvitedEmail      string `json:"invitedEmail"`
+	ServerID          int64  `json:"serverId"`
+	Accepted          bool   `json:"accepted"`
+	AcceptedAt        string `json:"acceptedAt"`
+	DeletedAt         string `json:"deletedAt"`
+	LeftAt            string `json:"leftAt"`
+	Owned             bool   `json:"owned"`
+	InviteToken       string `json:"inviteToken"`
+	MachineIdentifier string `json:"machineIdentifier"`
+	LastSeenAt        time.Time
+	NumLibraries      int64 `json:"numLibraries"`
 	Invited           struct {
-		ID         json.Number `json:"id"`
-		UUID       string      `json:"uuid"`
-		Title      string      `json:"title"`
-		Username   string      `json:"username"`
-		Restricted bool        `json:"restricted"`
-		Thumb      string      `json:"thumb"`
-		Status     string      `json:"status"`
+		ID         int64  `json:"id"`
+		UUID       string `json:"uuid"`
+		Title      string `json:"title"`
+		Username   string `json:"username"`
+		Restricted bool   `json:"restricted"`
+		Thumb      string `json:"thumb"`
+		Status     string `json:"status"`
 	} `json:"invited"`
 	SharingSettings struct {
-		AllowChannels    bool   `json:"allowChannels"`
-		FilterMovies     string `json:"filterMovies"`
-		FilterMusic      string `json:"filterMusic"`
-		FilterPhotos     string `json:"filterPhotos"`
-		FilterTelevision string `json:"filterTelevision"`
-		// FilterAll ??? I get null when testing. idk the true type
+		AllowChannels      bool        `json:"allowChannels"`
+		FilterMovies       string      `json:"filterMovies"`
+		FilterMusic        string      `json:"filterMusic"`
+		FilterPhotos       string      `json:"filterPhotos"`
+		FilterTelevision   string      `json:"filterTelevision"`
 		FilterAll          interface{} `json:"filterAll"`
 		AllowSync          bool        `json:"allowSync"`
 		AllowCameraUpload  bool        `json:"allowCameraUpload"`
 		AllowSubtitleAdmin bool        `json:"allowSubtitleAdmin"`
-		AllowTuners        json.Number `json:"allowTuners"`
+		AllowTuners        int64       `json:"allowTuners"`
 	} `json:"sharingSettings"`
 	Libraries []struct {
-		ID    json.Number `json:"id"`
-		Key   json.Number `json:"key"`
-		Title string      `json:"title"`
-		Type  string      `json:"type"`
+		ID    int64  `json:"id"`
+		Key   int64  `json:"key"`
+		Title string `json:"title"`
+		Type  string `json:"type"`
 	} `json:"libraries"`
 	AllLibraries bool `json:"allLibraries"`
+}
+
+// UnmarshalJSON for inviteFriendResponse parses flexible numeric fields.
+func (i *inviteFriendResponse) UnmarshalJSON(b []byte) error {
+	type alias inviteFriendResponse
+	var aux struct {
+		ID           json.RawMessage `json:"id"`
+		OwnerID      json.RawMessage `json:"ownerId"`
+		InvitedID    json.RawMessage `json:"invitedId"`
+		ServerID     json.RawMessage `json:"serverId"`
+		NumLibraries json.RawMessage `json:"numLibraries"`
+		Invited      struct {
+			ID json.RawMessage `json:"id"`
+		} `json:"invited"`
+		SharingSettings struct {
+			AllowTuners json.RawMessage `json:"allowTuners"`
+		} `json:"sharingSettings"`
+		Libraries []struct {
+			ID  json.RawMessage `json:"id"`
+			Key json.RawMessage `json:"key"`
+		} `json:"libraries"`
+		alias
+	}
+
+	if err := json.Unmarshal(b, &aux); err != nil {
+		return err
+	}
+
+	*i = inviteFriendResponse(aux.alias)
+
+	if v, err := parseFlexibleInt64(aux.ID); err == nil {
+		i.ID = v
+	} else {
+		return fmt.Errorf("invalid invite id: %w", err)
+	}
+	if v, err := parseFlexibleInt64(aux.OwnerID); err == nil {
+		i.OwnerID = v
+	} else {
+		return fmt.Errorf("invalid ownerId: %w", err)
+	}
+	if v, err := parseFlexibleInt64(aux.InvitedID); err == nil {
+		i.InvitedID = v
+	} else {
+		return fmt.Errorf("invalid invitedId: %w", err)
+	}
+	if v, err := parseFlexibleInt64(aux.ServerID); err == nil {
+		i.ServerID = v
+	} else {
+		return fmt.Errorf("invalid serverId: %w", err)
+	}
+	if v, err := parseFlexibleInt64(aux.NumLibraries); err == nil {
+		i.NumLibraries = v
+	} else {
+		return fmt.Errorf("invalid numLibraries: %w", err)
+	}
+	if v, err := parseFlexibleInt64(aux.Invited.ID); err == nil {
+		i.Invited.ID = v
+	} else {
+		return fmt.Errorf("invalid invited.id: %w", err)
+	}
+	if v, err := parseFlexibleInt64(aux.SharingSettings.AllowTuners); err == nil {
+		i.SharingSettings.AllowTuners = v
+	} else {
+		return fmt.Errorf("invalid allowTuners: %w", err)
+	}
+
+	// libraries: ensure we have a slice to populate even if alias unmarshalling didn't fill it
+	if len(i.Libraries) < len(aux.Libraries) {
+		// create a slice with the correct element shape
+		i.Libraries = make([]struct {
+			ID    int64  `json:"id"`
+			Key   int64  `json:"key"`
+			Title string `json:"title"`
+			Type  string `json:"type"`
+		}, len(aux.Libraries))
+	}
+
+	for idx, lib := range aux.Libraries {
+		if idx >= len(i.Libraries) {
+			break
+		}
+		if v, err := parseFlexibleInt64(lib.ID); err == nil {
+			i.Libraries[idx].ID = v
+		} else {
+			return fmt.Errorf("invalid library id: %w", err)
+		}
+		if v, err := parseFlexibleInt64(lib.Key); err == nil {
+			i.Libraries[idx].Key = v
+		} else {
+			return fmt.Errorf("invalid library key: %w", err)
+		}
+	}
+
+	return nil
 }
 
 // InviteFriendParams are the params to invite a friend
@@ -799,67 +906,67 @@ type TranscodeSessionsResponse struct {
 
 // Stream ...
 type Stream struct {
-	AlbumGain          string      `json:"albumGain"`
-	AlbumPeak          string      `json:"albumPeak"`
-	AlbumRange         string      `json:"albumRange"`
-	Anamorphic         bool        `json:"anamorphic"`
-	AudioChannelLayout string      `json:"audioChannelLayout"`
-	BitDepth           int         `json:"bitDepth"`
-	Bitrate            int         `json:"bitrate"`
-	BitrateMode        string      `json:"bitrateMode"`
-	Cabac              string      `json:"cabac"`
-	Channels           int         `json:"channels"`
-	ChromaLocation     string      `json:"chromaLocation"`
-	ChromaSubsampling  string      `json:"chromaSubsampling"`
-	Codec              string      `json:"codec"`
-	CodecID            string      `json:"codecID"`
-	ColorRange         string      `json:"colorRange"`
-	ColorSpace         string      `json:"colorSpace"`
-	Default            bool        `json:"default"`
-	DisplayTitle       string      `json:"displayTitle"`
-	Duration           string      `json:"duration"`
-	FrameRate          float64     `json:"frameRate"`
-	FrameRateMode      string      `json:"frameRateMode"`
-	Gain               string      `json:"gain"`
-	HasScalingMatrix   bool        `json:"hasScalingMatrix"`
-	Height             int         `json:"height"`
-	ID                 json.Number `json:"id"`
-	Index              int         `json:"index"`
-	Language           string      `json:"language"`
-	LanguageCode       string      `json:"languageCode"`
-	Level              int         `json:"level"`
-	Location           string      `json:"location"`
-	Loudness           string      `json:"loudness"`
-	Lra                string      `json:"lra"`
-	Peak               string      `json:"peak"`
-	PixelAspectRatio   string      `json:"pixelAspectRatio"`
-	PixelFormat        string      `json:"pixelFormat"`
-	Profile            string      `json:"profile"`
-	RefFrames          int         `json:"refFrames"`
-	SamplingRate       int         `json:"samplingRate"`
-	ScanType           string      `json:"scanType"`
-	Selected           bool        `json:"selected"`
-	StreamIdentifier   string      `json:"streamIdentifier"`
-	StreamType         int         `json:"streamType"`
-	Width              int         `json:"width"`
+	AlbumGain          string        `json:"albumGain"`
+	AlbumPeak          string        `json:"albumPeak"`
+	AlbumRange         string        `json:"albumRange"`
+	Anamorphic         bool          `json:"anamorphic"`
+	AudioChannelLayout string        `json:"audioChannelLayout"`
+	BitDepth           int           `json:"bitDepth"`
+	Bitrate            int           `json:"bitrate"`
+	BitrateMode        string        `json:"bitrateMode"`
+	Cabac              string        `json:"cabac"`
+	Channels           int           `json:"channels"`
+	ChromaLocation     string        `json:"chromaLocation"`
+	ChromaSubsampling  string        `json:"chromaSubsampling"`
+	Codec              string        `json:"codec"`
+	CodecID            string        `json:"codecID"`
+	ColorRange         string        `json:"colorRange"`
+	ColorSpace         string        `json:"colorSpace"`
+	Default            bool          `json:"default"`
+	DisplayTitle       string        `json:"displayTitle"`
+	Duration           string        `json:"duration"`
+	FrameRate          float64       `json:"frameRate"`
+	FrameRateMode      string        `json:"frameRateMode"`
+	Gain               string        `json:"gain"`
+	HasScalingMatrix   bool          `json:"hasScalingMatrix"`
+	Height             int           `json:"height"`
+	ID                 FlexibleInt64 `json:"id"`
+	Index              int           `json:"index"`
+	Language           string        `json:"language"`
+	LanguageCode       string        `json:"languageCode"`
+	Level              int           `json:"level"`
+	Location           string        `json:"location"`
+	Loudness           string        `json:"loudness"`
+	Lra                string        `json:"lra"`
+	Peak               string        `json:"peak"`
+	PixelAspectRatio   string        `json:"pixelAspectRatio"`
+	PixelFormat        string        `json:"pixelFormat"`
+	Profile            string        `json:"profile"`
+	RefFrames          int           `json:"refFrames"`
+	SamplingRate       int           `json:"samplingRate"`
+	ScanType           string        `json:"scanType"`
+	Selected           bool          `json:"selected"`
+	StreamIdentifier   string        `json:"streamIdentifier"`
+	StreamType         int           `json:"streamType"`
+	Width              int           `json:"width"`
 }
 
 // Part ...
 type Part struct {
-	AudioProfile          string      `json:"audioProfile"`
-	Container             string      `json:"container"`
-	Decision              string      `json:"decision"`
-	Duration              int         `json:"duration"`
-	File                  string      `json:"file"`
-	Has64bitOffsets       bool        `json:"has64bitOffsets"`
-	HasThumbnail          string      `json:"hasThumbnail"`
-	ID                    json.Number `json:"id"`
-	Key                   string      `json:"key"`
-	OptimizedForStreaming boolOrInt   `json:"optimizedForStreaming"`
-	Selected              bool        `json:"selected"`
-	Size                  int         `json:"size"`
-	Stream                []Stream    `json:"Stream"`
-	VideoProfile          string      `json:"videoProfile"`
+	AudioProfile          string        `json:"audioProfile"`
+	Container             string        `json:"container"`
+	Decision              string        `json:"decision"`
+	Duration              int           `json:"duration"`
+	File                  string        `json:"file"`
+	Has64bitOffsets       bool          `json:"has64bitOffsets"`
+	HasThumbnail          string        `json:"hasThumbnail"`
+	ID                    FlexibleInt64 `json:"id"`
+	Key                   string        `json:"key"`
+	OptimizedForStreaming boolOrInt     `json:"optimizedForStreaming"`
+	Selected              bool          `json:"selected"`
+	Size                  int           `json:"size"`
+	Stream                []Stream      `json:"Stream"`
+	VideoProfile          string        `json:"videoProfile"`
 }
 
 // Player ...
@@ -898,14 +1005,14 @@ type CurrentSessions struct {
 
 // Rating
 type Rating struct {
-	Image string      `json:"image"`
-	Type  string      `json:"type"`
-	Value json.Number `json:"value"`
+	Image string        `json:"image"`
+	Type  string        `json:"type"`
+	Value FlexibleInt64 `json:"value"`
 }
 
 // Genre
 type Genre struct {
-	Filter string      `json:"filter"`
-	ID     json.Number `json:"id"`
-	Tag    string      `json:"tag"`
+	Filter string        `json:"filter"`
+	ID     FlexibleInt64 `json:"id"`
+	Tag    string        `json:"tag"`
 }

--- a/vendor/github.com/jrudio/go-plex-client/models_invite_test.go
+++ b/vendor/github.com/jrudio/go-plex-client/models_invite_test.go
@@ -1,0 +1,84 @@
+package plex
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestInviteFriendResponseQuotedIDs(t *testing.T) {
+	payload := `{
+	    "id":"101",
+	    "name":"Alice",
+	    "ownerId":"202",
+	    "invitedId":"303",
+	    "serverId":"404",
+	    "numLibraries":"2",
+	    "invited": { "id": "505", "uuid":"u","title":"t","username":"u","restricted":false,"thumb":"","status":"" },
+	    "sharingSettings": { "allowTuners": "1" },
+	    "libraries": [ { "id": "11", "key": "22", "title": "L", "type": "movie" } ]
+	}`
+
+	var ir inviteFriendResponse
+	if err := json.Unmarshal([]byte(payload), &ir); err != nil {
+		t.Fatalf("unmarshal inviteFriendResponse failed: %v", err)
+	}
+
+	if ir.ID != 101 || ir.OwnerID != 202 || ir.InvitedID != 303 || ir.ServerID != 404 {
+		t.Fatalf("unexpected invite ids: %+v", ir)
+	}
+	if ir.NumLibraries != 2 {
+		t.Fatalf("unexpected NumLibraries: %d", ir.NumLibraries)
+	}
+	if len(ir.Libraries) != 1 || ir.Libraries[0].ID != 11 || ir.Libraries[0].Key != 22 {
+		t.Fatalf("unexpected libraries: %+v", ir.Libraries)
+	}
+}
+
+func TestPlexInviteFriendFlow(t *testing.T) {
+	// start an httptest server to mock plex.tv
+	srv := httpTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// verify path and method
+		if r.Method != "POST" || !strings.HasSuffix(r.URL.Path, "/api/v2/shared_servers") {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+
+		// read body to ensure it contains invitedEmail and librarySectionIds
+		body, _ := io.ReadAll(r.Body)
+		if !bytes.Contains(body, []byte("invitedEmail")) {
+			t.Fatalf("request body missing invitedEmail: %s", string(body))
+		}
+
+		// respond with created and a valid JSON body
+		w.WriteHeader(http.StatusCreated)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"1","ownerId":"2","invitedId":"3","serverId":"4","numLibraries":"0","invited":{"id":"5"},"sharingSettings":{"allowTuners":"0"},"libraries":[]}`))
+	})
+	defer srv.Close()
+
+	// override plexURL for this test
+	old := plexURL
+	plexURL = srv.URL
+	defer func() { plexURL = old }()
+
+	p, err := New(srv.URL, "token")
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+
+	params := InviteFriendParams{UsernameOrEmail: "a@b.c", MachineID: "m", Label: "", LibraryIDs: []int{1}}
+
+	if err := p.InviteFriend(params); err != nil {
+		t.Fatalf("InviteFriend failed: %v", err)
+	}
+}
+
+// httpTestServer is a small helper to create an httptest.Server with a handler.
+func httpTestServer(t *testing.T, h func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(h))
+}

--- a/vendor/github.com/jrudio/go-plex-client/plex.go
+++ b/vendor/github.com/jrudio/go-plex-client/plex.go
@@ -20,8 +20,12 @@ import (
 	"github.com/google/uuid"
 )
 
+var (
+	// plexURL is a variable so tests can override it (httptest) for integration testing.
+	plexURL = "https://plex.tv"
+)
+
 const (
-	plexURL         = "https://plex.tv"
 	applicationXml  = "application/xml"
 	applicationJson = "application/json"
 )
@@ -622,7 +626,13 @@ func (p *Plex) InviteFriend(params InviteFriendParams) error {
 
 	label := url.QueryEscape(params.Label)
 
-	query := fmt.Sprintf("%s/api/v2/shared_servers", plexURL)
+	// Prefer the instance URL if set (testability / local servers). Fall back to plex.tv.
+	base := plexURL
+	if p.URL != "" {
+		base = p.URL
+	}
+
+	query := fmt.Sprintf("%s/api/v2/shared_servers", base)
 
 	var requestBody inviteFriendBody
 


### PR DESCRIPTION
Plex timeline notifications (the NotificationContainer with TimelineEntry) often serialize IDs as strings; you can see real‑world examples with "sectionID":"15". Your exporter currently defines those fields as numeric types, so Go refuses to unmarshal a quoted number.  This fixes that.